### PR TITLE
chore(CI): archive the contract binaries to GitHub artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,3 +77,13 @@ jobs:
         run: make build
       - name: Unit Testing
         run: make test
+
+      - name: Print the size of each binaries and the cumulative size of each directory
+        if: matrix.os == 'ubuntu-latest'
+        run: tree -s --du build
+      - name: Archive the contract binaries ${{ github.sha }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: btc-spv-contract-binaries-${{ matrix.os }}-${{ github.sha }}
+          path: |
+            build/release


### PR DESCRIPTION
So that a developer can download the contract binaries directly to a server and then run [ckb-bitcoin-spv-service](https://github.com/ckb-cell/ckb-bitcoin-spv-service).